### PR TITLE
Optimize git repo fetch

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -157,9 +157,12 @@ function getrepo() {
 
   pushd "$SOURCES_DIR"
   if [ ! -d "$dirname" ]; then
-    git clone "$url" "$dirname"
+    mkdir "$dirname"
     pushd "$dirname"
-    git checkout "$rev"
+    git init
+    git remote add origin "$url"
+    git fetch --depth=1 origin "$rev" || git fetch origin
+    git reset --hard "$rev"
     popd
   fi
   popd


### PR DESCRIPTION
Instead of clonning the whole repository with all its history, fetch just the specific commit. This should reduce fetch time significantly, especially for repos with long history.