### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,10 @@
 	"features": {
 		"ghcr.io/devcontainers-extra/features/apt-packages:1": {
 			"packages" : [
-				"python3"
+				"python3",
+				"cmake",
+				"tcl",
+				"zstd"
 			]
 		}
 	}


### PR DESCRIPTION
adds a dev container that can be used with vscode on all other linux distros.